### PR TITLE
Use current time (now) in example journey planner query

### DIFF
--- a/defaultQuery.js
+++ b/defaultQuery.js
@@ -1,3 +1,5 @@
+import { toISOStringWithTimezone } from './utils/time'
+
 const defaultQuery = {
     'JourneyPlanner': `
 # Welcome to GraphiQL
@@ -31,7 +33,7 @@ const defaultQuery = {
       name:"Alna, Oslo"
     }
     numTripPatterns: 3
-    dateTime: "2018-01-04T12:51:14.000+0100"
+    dateTime: "${toISOStringWithTimezone(new Date())}"
     minimumTransferTime: 180
     walkSpeed: 1.3
     wheelchair: false
@@ -46,7 +48,7 @@ const defaultQuery = {
       walkDistance
 
           legs {
-          
+
             mode
             distance
             line {

--- a/utils/time.js
+++ b/utils/time.js
@@ -1,0 +1,14 @@
+export function toISOStringWithTimezone(date) {
+    const year = date.getFullYear()
+    const month = `${date.getMonth()}`.padStart(2, '0')
+    const day = `${date.getDate()}`.padStart(2, '0')
+    const hours = `${date.getHours()}`.padStart(2, '0')
+    const minutes = `${date.getMinutes()}`.padStart(2, '0')
+    const seconds = `${date.getSeconds()}`.padStart(2, '0')
+    const ms = `${date.getMilliseconds()}`.padStart(3, '0')
+
+    const offsetHours = `${date.getTimezoneOffset() / -60}`.padStart(2, '0')
+    const timezonePostfix = offsetHours === 0 ? 'Z' : `+${offsetHours}:00`
+
+    return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}.${ms}${timezonePostfix}`
+}


### PR DESCRIPTION
Brukar "no" i staden for "2018-01-04T12:51:14.000+0100", som ikkje gir reiseresultat.