### PR TITLE
Add support for `prefers-color-scheme`

### DIFF
--- a/components/App.js
+++ b/components/App.js
@@ -7,6 +7,7 @@ import '../css/graphiql.css'
 import '../css/custom.css'
 import { getQueryParameters } from '../utils/'
 import graphQLFetcher from '../utils/graphQLFetcher'
+import getPreferredTheme from '../utils/getPreferredTheme'
 
 import * as journeyplannerQueries from '../queries/journeyplanner'
 import * as nsrQueries from '../queries/nsr'
@@ -14,7 +15,7 @@ import * as nsrQueries from '../queries/nsr'
 import GeocoderModal from './GeocoderModal'
 
 let logo
-if (window.localStorage.getItem('theme') === 'dark') {
+if (getPreferredTheme() === 'dark') {
   require('../css/darktheme.css')
   logo = require('../static/img/entur-white.png')
 } else {

--- a/utils/getPreferredTheme.js
+++ b/utils/getPreferredTheme.js
@@ -1,0 +1,12 @@
+const getPreferredTheme = () => {
+    const savedTheme = window.localStorage && window.localStorage.getItem('theme')
+    if (['light', 'dark'].includes(savedTheme)) {
+        return savedTheme
+    } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        return 'dark'
+    } else {
+        return 'light'
+    }
+};
+
+export default getPreferredTheme;


### PR DESCRIPTION
We check for the preferred Theme to set in multiple steps:

1. If theme was explicitly set (in `localStorage` already) use the specified theme.
2. If `prefers-color-scheme: dark` is set, use dark theme.
3. Fall back to light theme.

Closes #26