### PR TITLE
Tweak dark theme colors

### DIFF
--- a/css/darktheme.css
+++ b/css/darktheme.css
@@ -114,8 +114,20 @@
     background: #21262b;
 }
 
-.graphiql-container .execute-options > li.selected, .graphiql-container .toolbar-menu-items > li.hover, .graphiql-container .toolbar-menu-items > li:active, .graphiql-container .toolbar-menu-items > li:hover, .graphiql-container .toolbar-select-options > li.hover, .graphiql-container .toolbar-select-options > li:active, .graphiql-container .toolbar-select-options > li:hover, .graphiql-container .history-contents > p:hover, .graphiql-container .history-contents > p:active {
+.graphiql-container .execute-options > li.selected,
+.graphiql-container .toolbar-menu-items > li.hover,
+.graphiql-container .toolbar-menu-items > li:active,
+.graphiql-container .toolbar-menu-items > li:hover,
+.graphiql-container .toolbar-select-options > li.hover,
+.graphiql-container .toolbar-select-options > li:active,
+.graphiql-container .toolbar-select-options > li:hover,
+.graphiql-container .history-contents > p:hover,
+.graphiql-container .history-contents > p:active {
     background: #383C41;
+}
+
+.graphiql-container .toolbar-menu-items > li {
+    color: #383C41;
 }
 
 .graphiql-container .doc-category-title {
@@ -133,6 +145,19 @@
 
 .cm-property {
     color: #A5ACB8;
+}
+
+.cm-punctuation {
+    color: #ACACAC;
+}
+
+.cm-ws {
+    color: #ACACAC;
+}
+
+.graphiql-container div.CodeMirror span.CodeMirror-matchingbracket {
+  color: #ACACAC;
+  text-decoration: underline;
 }
 
 .cm-string {


### PR DESCRIPTION
Tweaked contrast issues as mentioned in #28 

![image](https://user-images.githubusercontent.com/24277692/66265161-3f065f80-e82f-11e9-8c06-1e9c387a9c40.png)
![image](https://user-images.githubusercontent.com/24277692/66265179-71b05800-e82f-11e9-969f-47165cae741a.png)

I did notice that the commas seem to be under the class `.cm-ws` rather than `.cm-punctuation`.
Is that expected behaviour? For now I just tweaked the colour of `.cm-ws` to resolve the comma issue, as I'm not sure how else to classify it correctly (I have little to no experience with React).

