### PR TITLE
Remove pointsOnLink from default example query

### DIFF
--- a/queries/journeyplanner/trip.js
+++ b/queries/journeyplanner/trip.js
@@ -52,10 +52,6 @@ export default `
           id
           publicCode
         }
-        pointsOnLink {
-          points
-          length
-        }
       }
     }
   }


### PR DESCRIPTION
It's annoying because it takes too much space in results, and I don't think most people care about it.