### PR TITLE
Integrate Prettier with ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+    extends: "react-app",
+    plugins: [
+        "prettier",
+    ],
+    rules: {
+        "prettier/prettier": "error",
+    }
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "isomorphic-fetch": "^2.2.1",
     "lint-staged": "^9.5.0",
     "lodash.debounce": "^4.0.8",
-    "prettier": "^1.19.1",
     "query-string": "^6.9.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
@@ -37,10 +36,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
+    "lint": "eslint src",
     "format": "prettier --write src/**/*.{js,jsx,ts,tsx,json,css,scss,md}"
-  },
-  "eslintConfig": {
-    "extends": "react-app"
   },
   "browserslist": {
     "production": [
@@ -68,5 +65,9 @@
   "prettier": {
     "singleQuote": true
   },
-  "homepage": "/graphql-explorer"
+  "homepage": "/graphql-explorer",
+  "devDependencies": {
+    "eslint-plugin-prettier": "^3.1.2",
+    "prettier": "^1.19.1"
+  }
 }

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -1,1 +1,1 @@
-export { default } from "./App";
+export { default } from './App';

--- a/src/components/GeocoderModal/GeocoderModal.js
+++ b/src/components/GeocoderModal/GeocoderModal.js
@@ -1,9 +1,9 @@
-import React, { useState, useEffect, useRef } from "react";
-import debounce from "lodash.debounce";
-import EnturService from "@entur/sdk";
-import getPreferredTheme from "utils/getPreferredTheme";
+import React, { useState, useEffect, useRef } from 'react';
+import debounce from 'lodash.debounce';
+import EnturService from '@entur/sdk';
+import getPreferredTheme from 'utils/getPreferredTheme';
 
-import { TextField } from "@entur/form";
+import { TextField } from '@entur/form';
 import {
   Table,
   TableHead,
@@ -11,16 +11,16 @@ import {
   TableRow,
   HeaderCell as TableHeaderCell,
   DataCell as TableDataCell
-} from "@entur/table";
-import { CloseIcon } from "@entur/icons";
+} from '@entur/table';
+import { CloseIcon } from '@entur/icons';
 
-import "@entur/form/dist/styles.css";
-import "@entur/table/dist/styles.css";
-import "@entur/icons/dist/styles.css";
+import '@entur/form/dist/styles.css';
+import '@entur/table/dist/styles.css';
+import '@entur/icons/dist/styles.css';
 
-import "./styles.css";
+import './styles.css';
 
-const service = new EnturService({ clientName: "entur-shamash" });
+const service = new EnturService({ clientName: 'entur-shamash' });
 
 const autocompleteSearch = debounce(
   (query, callback) =>
@@ -33,7 +33,7 @@ const autocompleteSearch = debounce(
 );
 
 function GeocoderModal({ onDismiss }) {
-  const [query, setQuery] = useState("");
+  const [query, setQuery] = useState('');
   const [results, setResults] = useState([]);
   const modalRef = useRef(null);
   const [copiedPopupStyle, setCopiedPopupStyle] = useState({
@@ -54,8 +54,8 @@ function GeocoderModal({ onDismiss }) {
 
   const handleRowClick = (newClip, event) => {
     const { clientX, clientY } = event;
-    navigator.permissions.query({ name: "clipboard-write" }).then(result => {
-      if (result.state === "granted" || result.state === "prompt") {
+    navigator.permissions.query({ name: 'clipboard-write' }).then(result => {
+      if (result.state === 'granted' || result.state === 'prompt') {
         navigator.clipboard.writeText(newClip).then(
           function() {
             const { offsetLeft = 0, offsetTop = 0 } = modalRef
@@ -153,7 +153,7 @@ function GeocoderModal({ onDismiss }) {
                   <TableDataCell
                     className={`geocoder-modal__table-data--${theme}`}
                   >
-                    {category.join(", ")}
+                    {category.join(', ')}
                   </TableDataCell>
                 </TableRow>
               );

--- a/src/components/GeocoderModal/index.js
+++ b/src/components/GeocoderModal/index.js
@@ -1,1 +1,1 @@
-export { default } from "./GeocoderModal";
+export { default } from './GeocoderModal';

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
-import React from "react";
-import ReactDOM from "react-dom";
-import App from "components/App";
-import * as serviceWorker from "./serviceWorker";
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from 'components/App';
+import * as serviceWorker from './serviceWorker';
 
-ReactDOM.render(<App />, document.getElementById("root"));
+ReactDOM.render(<App />, document.getElementById('root'));
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/src/queries/journey-planner/index.js
+++ b/src/queries/journey-planner/index.js
@@ -1,3 +1,3 @@
-export { default as bikeRentalStationsByBboxQuery } from "./bikeRentalStationsByBbox";
-export { default as stopPlaceQuery } from "./stopPlace";
-export { default as tripQuery } from "./trip";
+export { default as bikeRentalStationsByBboxQuery } from './bikeRentalStationsByBbox';
+export { default as stopPlaceQuery } from './stopPlace';
+export { default as tripQuery } from './trip';

--- a/src/queries/journey-planner/trip.js
+++ b/src/queries/journey-planner/trip.js
@@ -1,4 +1,4 @@
-import { toISOStringWithTimezone } from "../../utils/time";
+import { toISOStringWithTimezone } from '../../utils/time';
 
 export default `
 # Welcome to GraphiQL

--- a/src/queries/stop-places/index.js
+++ b/src/queries/stop-places/index.js
@@ -1,2 +1,2 @@
-export { default as stopPlaceQuery } from "./stopPlace";
-export { default as topographicPlaceQuery } from "./topographicPlace";
+export { default as stopPlaceQuery } from './stopPlace';
+export { default as topographicPlaceQuery } from './topographicPlace';

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,4 +1,4 @@
-const configureApp = require("../server-config").configureApp;
+const configureApp = require('../server-config').configureApp;
 
 module.exports = function(app) {
   configureApp(app);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3626,6 +3626,13 @@ eslint-plugin-jsx-a11y@6.2.3:
     has "^1.0.3"
     jsx-ast-utils "^2.2.1"
 
+eslint-plugin-prettier@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz#432e5a667666ab84ce72f945c72f77d996a5c9ba"
+  integrity sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 eslint-plugin-react-hooks@^1.6.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz#6210b6d5a37205f0b92858f895a4e827020a7d04"
@@ -3922,6 +3929,11 @@ extsprintf@^1.2.0:
 fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^2.0.2:
   version "2.2.7"
@@ -7856,6 +7868,13 @@ prelude-ls@~1.1.2:
 prepend-http@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
 
 prettier@^1.19.1:
   version "1.19.1"


### PR DESCRIPTION
Runs Prettier as an ESLint rule, which supports editors that have ESLint configured.
A `yarn lint` script is also added. Run `yarn lint --fix` for autofixing.