### PR TITLE
Make default trip query compatible with both OTP 1 and 2

### DIFF
--- a/src/queries/journey-planner/trip.js
+++ b/src/queries/journey-planner/trip.js
@@ -34,9 +34,7 @@ export default {
     }
     numTripPatterns: 3
     dateTime: "${toISOStringWithTimezone(new Date())}"
-    minimumTransferTime: 180
     walkSpeed: 1.3
-    wheelchair: false
     arriveBy: false
   )
 


### PR DESCRIPTION
Avoid this in Shamash for OTP 2:
![image](https://user-images.githubusercontent.com/4339443/96843054-283ca600-144e-11eb-8171-07e4851ee37b.png)
