### PR TITLE
Fix setup for running local dev server

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+PUBLIC_URL=/


### PR DESCRIPTION
Without this, running 'yarn start' would should run a crashed white page.
Replaces #62