### PR TITLE
chore(deps): low-risk sweep 2 — pin GH actions + uuid patch

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -14,13 +14,13 @@ concurrency:
 jobs:
   build:
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v6.0.3
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: 24.16.0
       - name: Cache node modules
         id: cache-npm
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         env:
           cache-name: cache-node-modules
         with:
@@ -39,7 +39,7 @@ jobs:
           REACT_APP_VERSION: ${{ github.sha }}
           REACT_APP_ENTUR_CLIENT_NAME: entur-shamash2023
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: build
           path: |
@@ -50,13 +50,13 @@ jobs:
     needs: [build]
     environment: 'dev'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.3
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: build
           path: build
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - uses: FirebaseExtended/action-hosting-deploy@v0.10.0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_ENT_SHAMASH_DEV }}'
@@ -67,13 +67,13 @@ jobs:
     needs: [deploy_dev]
     environment: 'staging'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.3
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: build
           path: build
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - uses: FirebaseExtended/action-hosting-deploy@v0.10.0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_ENT_SHAMASH_TST }}'
@@ -84,13 +84,13 @@ jobs:
     needs: [deploy_dev, deploy_staging]
     environment: 'prod'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.3
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: build
           path: build
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - uses: FirebaseExtended/action-hosting-deploy@v0.10.0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_ENT_SHAMASH_PRD }}'

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -8,13 +8,13 @@ jobs:
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v6.0.3
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: 24.16.0
       - name: Cache node modules
         id: cache-npm
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         env:
           cache-name: cache-node-modules
         with:
@@ -34,7 +34,7 @@ jobs:
           REACT_APP_ENTUR_CLIENT_NAME: entur-shamash2023
           PUBLIC_URL: ''
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: build
           path: |
@@ -44,13 +44,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.3
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: build
           path: build
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - uses: FirebaseExtended/action-hosting-deploy@v0.10.0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_ENT_SHAMASH_DEV }}'

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "react-test-renderer": "19.2.7",
         "sass": "1.101.0",
         "typescript": "6.0.3",
-        "uuid": "13.0.1"
+        "uuid": "13.0.2"
       },
       "devDependencies": {
         "@testing-library/dom": "10.4.1",
@@ -10914,9 +10914,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.1.tgz",
-      "integrity": "sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-test-renderer": "19.2.7",
     "sass": "1.101.0",
     "typescript": "6.0.3",
-    "uuid": "13.0.1"
+    "uuid": "13.0.2"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Second low-risk consolidation, now that #543 (GraphiQL 5 + React 19) is on master.

### Included
- **Pin GitHub Actions to exact patch tags** (supersedes #537): `actions/checkout` v6→v6.0.3, `actions/setup-node` v6→v6.4.0, `actions/cache` v5→v5.0.5, `actions/upload-artifact` v7→v7.0.1, `actions/download-artifact` v8→v8.0.1, `FirebaseExtended/action-hosting-deploy` v0→v0.10.0.
- **uuid** 13.0.1 → 13.0.2 (patch) (supersedes #538).

### Verification
- `npm run build` ✓ · `npm run test:run` → 15/15.

### Notes
- **#411 (js-yaml 4.1.0→4.1.1) excluded** — js-yaml is no longer in the dependency tree (dropped by the recent eslint/other upgrades), so that PR is obsolete and is being closed.
- Majors left for direct merge: #539 (graphql 17), #540 (uuid 14), #541 (@entur/icons 9). Note #539 and #540 each conflict with this PR's deps — pick one uuid path.
- #544 (monaco-editor 0.55.1) on hold — must stay pinned at 0.52.2 for GraphiQL compat.

Supersedes #537, #538.